### PR TITLE
Add templated HTML generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Auditor Trading
+
+This project generates a simple static site from template data.
+
+## Usage
+
+1. Edit the values in `data/data.json` to update dashboard numbers, monthly returns and statistics.
+2. Run `python scripts/generate_site.py` to render `templates/index_template.html` into `index.html`.
+
+The script requires [Jinja2](https://palletsprojects.com/p/jinja/) which can be installed with:
+
+```bash
+pip install jinja2
+```

--- a/data/data.json
+++ b/data/data.json
@@ -1,0 +1,44 @@
+{
+  "last_update": "03/06/2025",
+  "participacion_banner": "Participando en DarwinIA Silver - JUNIO",
+  "status_bar": {
+    "ranking": "576 \u2191",
+    "darwin": "PONA",
+    "score": "78.30",
+    "capital": "\u20ac30000.00"
+  },
+  "dashboard": [
+    {"label": "Rentabilidad (a origen)", "value": "8.33%", "class": "positivo"},
+    {"label": "Drawdown m\u00e1ximo", "value": "-6.70%", "class": "negativo"},
+    {"label": "Rentabilidad (\u00faltimos 6 meses)", "value": "11.08%", "class": "positivo"},
+    {"label": "Activos bajo gesti\u00f3n", "value": "60,000 \u20ac"}
+  ],
+  "monthly_returns": {
+    "2025": {
+      "Ene": {"value": "1.89%", "class": "positivo"},
+      "Feb": {"value": "3.35%", "class": "positivo"},
+      "Mar": {"value": "0.05%", "class": "positivo"},
+      "Abr": {"value": "5.41%", "class": "positivo"},
+      "May": {"value": "0.25%", "class": "positivo"},
+      "Jun": {"value": "0.07%", "class": "positivo"}
+    },
+    "2024": {
+      "Oct": {"value": "-2.60%", "class": "negativo"},
+      "Nov": {"value": "+0.12%", "class": "positivo"},
+      "Dic": {"value": "-0.30%", "class": "negativo"}
+    }
+  },
+  "stats_table": [
+    {"label": "Operaciones", "value": "442"},
+    {"label": "% exposici\u00f3n larga", "value": "85.88%"},
+    {"label": "Frecuencia diaria", "value": "2.57"},
+    {"label": "% ganadoras", "value": "56.56%"},
+    {"label": "Factor de beneficio", "value": "1.28"},
+    {"label": "Operaci\u00f3n ganadora media", "value": "0.17%"},
+    {"label": "Operaci\u00f3n perdedora media", "value": "-0.17%"},
+    {"label": "Ratio de payoff", "value": "0.98"},
+    {"label": "Duraci\u00f3n media perdedora", "value": "21h 6m"},
+    {"label": "Duraci\u00f3n media ganadora", "value": "21h 51m"},
+    {"label": "Ratio de duraci\u00f3n", "value": "1.04"}
+  ]
+}

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+from jinja2 import Environment, FileSystemLoader
+
+
+def main():
+    data_path = Path('data/data.json')
+    with data_path.open('r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    env = Environment(loader=FileSystemLoader('templates'))
+    template = env.get_template('index_template.html')
+
+    months_order = [
+        "Ene", "Feb", "Mar", "Abr", "May", "Jun",
+        "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"
+    ]
+
+    rendered = template.render(**data, months_order=months_order)
+    output_path = Path('index.html')
+    with output_path.open('w', encoding='utf-8') as f:
+        f.write(rendered)
+    print(f"Generated {output_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>YQuant - Auditoría Darwinex</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: 'Segoe UI', sans-serif;
+      background-color: #121212;
+      color: #ffffff;
+    }
+    header {
+      text-align: center;
+      padding: 10px;
+      background-color: #1b1b1b;
+      border-bottom: 2px solid #4CAF50;
+    }
+    h1 {
+      font-size: 20px;
+      margin: 5px 0;
+    }
+    .update-date {
+      color: #4CAF50;
+      font-size: 12px;
+    }
+    .participacion-banner {
+      text-align: center;
+      padding: 10px;
+      background-color: #1f1f1f;
+      font-size: 14px;
+      color: #4CAF50;
+      font-weight: bold;
+      margin-bottom: 16px;
+    }
+    .status-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: #2a2a2a;
+      padding: 10px;
+      margin: 0 auto;
+      max-width: 390px;
+      border-radius: 8px;
+      color: white;
+      font-weight: bold;
+      font-size: 14px;
+    }
+    .status-bar span {
+      background: #4CAF50;
+      color: black;
+      padding: 4px 8px;
+      border-radius: 6px;
+      margin: 0 6px;
+    }
+    section {
+      padding: 15px;
+      margin: 10px;
+      background-color: #1e1e1e;
+      border-radius: 10px;
+      box-shadow: 0 0 5px rgba(0,0,0,0.3);
+    }
+    section h2 {
+      color: #4CAF50;
+      font-size: 16px;
+      margin-bottom: 10px;
+    }
+    .dashboard-cards {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+    }
+    .card {
+      background: #2a2a2a;
+      padding: 10px;
+      border-radius: 8px;
+      text-align: center;
+    }
+    .card strong {
+      display: block;
+      color: #aaaaaa;
+      font-size: 12px;
+    }
+    .card span {
+      font-size: 16px;
+      font-weight: bold;
+    }
+    .positivo { color: #4CAF50; }
+    .negativo { color: #ef5350; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      overflow-x: auto;
+    }
+    th, td {
+      padding: 6px;
+      font-size: 12px;
+      text-align: center;
+      border-bottom: 1px solid #333;
+    }
+    th {
+      color: #4CAF50;
+      font-weight: bold;
+    }
+    .telegram-btn {
+      display: block;
+      text-align: center;
+      background-color: #4CAF50;
+      color: black;
+      padding: 10px;
+      margin: 20px auto;
+      width: fit-content;
+      border-radius: 8px;
+      text-decoration: none;
+      font-size: 14px;
+    }
+    footer {
+      text-align: center;
+      font-size: 12px;
+      color: #4CAF50;
+      margin-top: 30px;
+      padding: 10px;
+    }
+    .stats-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    .stats-table th, .stats-table td {
+      padding: 8px 5px;
+      text-align: left;
+      border-bottom: 1px solid #333;
+    }
+    .stats-table th {
+      color: #aaaaaa;
+      font-weight: normal;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>YQuant Trading</h1>
+    <div class="update-date">Actualizado el {{ last_update }}</div>
+  </header>
+
+  <div class="participacion-banner">{{ participacion_banner }}</div>
+  <div class="status-bar">
+    <div>{{ status_bar.ranking }}</div>
+    <span>{{ status_bar.darwin }}</span>
+    <div>{{ status_bar.score }}</div>
+    <div>{{ status_bar.capital }}</div>
+  </div>
+
+  <section>
+    <h2>PONA - DarwinIA SILVER <span style="float:right; color:#4CAF50;">Activo</span></h2>
+    <p style="margin-top:5px;font-size:13px;line-height:1.4;">Un DARWIN es un índice invertible con gestión de riesgo independiente que combina las señales del trader con el Motor de Gestión de Riesgo de Darwinex Zero.</p>
+    <div class="dashboard-cards" style="margin-top:15px;">
+      {% for card in dashboard %}
+      <div class="card">
+        <strong>{{ card.label }}</strong>
+        <span{% if card.class %} class="{{ card.class }}"{% endif %}>{{ card.value }}</span>
+      </div>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section>
+    <h2>Retornos Mensuales</h2>
+    <div class="scroll-hint">Desliza para ver más &raquo;</div>
+    <div style="overflow-x:auto;">
+      <table>
+        <thead>
+          <tr>
+            <th>Año</th>
+            {% for m in months_order %}<th>{{ m }}</th>{% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for year, months in monthly_returns.items() %}
+          <tr>
+            <td>{{ year }}</td>
+            {% for m in months_order %}
+            {% set data = months.get(m) %}
+            <td{% if data and data.class %} class="{{ data.class }}"{% endif %}>{{ data.value if data else '' }}</td>
+            {% endfor %}
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2>Estadísticas de la Estrategia</h2>
+    <table class="stats-table">
+      <tbody>
+        {% for stat in stats_table %}
+        <tr><th>{{ stat.label }}</th><td>{{ stat.value }}</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+  <a class="telegram-btn" href="https://t.me/+ZEyJumHzmxYzMzMx" target="_blank">Únete a la comunidad en Telegram</a>
+
+  <footer>
+    <p>&copy; 2025 YQuant Trading Systems | yquant10@gmail.com</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- store dashboard and statistics values in `data/data.json`
- add Jinja2 HTML template at `templates/index_template.html`
- create `scripts/generate_site.py` to render `index.html`
- document how to update the site in `README.md`

## Testing
- `python scripts/generate_site.py` *(fails: No module named 'jinja2')*
- `pip install jinja2` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68405d4b402c83209e4da39d91e0d498